### PR TITLE
Workaround for AcceptExternalModificationsToPlayer error

### DIFF
--- a/Assets/Editor/Scripts/SimpleBuild/BuildPlayer.cs
+++ b/Assets/Editor/Scripts/SimpleBuild/BuildPlayer.cs
@@ -198,7 +198,9 @@ namespace SimpleBuild {
                 // default: Append 設定 / BUILD_CLEAN=true で Replace 設定
                 if (BuildTarget == BuildTarget.iOS && Environment.GetEnvironmentVariable(EnvironmentVariableBuildFaster) == "true")
                 {
-                    options.options |= UnityEditor.BuildOptions.AcceptExternalModificationsToPlayer;
+                    // Waiting for fix:
+                    // https://issuetracker.unity3d.com/issues/buildoptions-dot-acceptexternalmodificationstoplayer-throws-error-when-building-for-ios-if-the-xcode-project-does-not-already-exist
+                    // options.options |= UnityEditor.BuildOptions.AcceptExternalModificationsToPlayer;
                 }
             }
             options.options |= UnityEditor.BuildOptions.CompressWithLz4;


### PR DESCRIPTION
iOS ビルドで 2019.4.13f1 / 2020.1.10f1 以降でエラーになってしまう問題への対処

https://issuetracker.unity3d.com/issues/buildoptions-dot-acceptexternalmodificationstoplayer-throws-error-when-building-for-ios-if-the-xcode-project-does-not-already-exist

によると Issue は最近 file されたので、しばらくすれば修正されると思うが、それまでの間の workaround

ビルドを試した結果

* ブックオフ: 8分23秒で目立った変化、低下はなし
* 本体: 47分39秒で目立った変化、低下はなし

じゃあ逆に修正されてもこのオプション設定する必要ある？？？ という疑問もある